### PR TITLE
[FE] 질문 상세조회 페이지 레이아웃 완성

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,17 +1,13 @@
 import React from "react";
 import styled, { createGlobalStyle } from "styled-components";
 import Footer from "./components/Footer";
-import Header from "./components/Header";
-import LeftSidebar from "./components/LeftSidebar";
 import QuestionContentPage from "./page/QuestionContentPage";
 
 function App() {
   return (
     <>
       <GlobalStyles />
-      <Header />
       <Wrapper>
-        <LeftSidebar />
         <QuestionContentPage />
       </Wrapper>
       <FooterBox />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import styled, { createGlobalStyle } from "styled-components";
+
+import Header from "./components/Header";
 import Footer from "./components/Footer";
 import QuestionContentPage from "./page/QuestionContentPage";
 
@@ -7,6 +9,7 @@ function App() {
   return (
     <>
       <GlobalStyles />
+      <Header />
       <Wrapper>
         <QuestionContentPage />
       </Wrapper>

--- a/client/src/page/QuestionContentPage.tsx
+++ b/client/src/page/QuestionContentPage.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { styled } from "styled-components";
 
-import Header from "../components/Header";
 import LeftSidebar from "../components/LeftSidebar";
 import RightSidebar from "../components/RightSidebar/Index";
 import QuestionContentTitle from "../components/QuestionContentTitle/Index";
@@ -14,7 +13,6 @@ const Title = QuestionContentTitle;
 const QuestionContentPage = () => {
   return (
     <Body>
-      <Header />
       <TotalContainer>
         <LeftSidebar />
         <MainContainer>

--- a/client/src/page/QuestionContentPage.tsx
+++ b/client/src/page/QuestionContentPage.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { styled } from "styled-components";
 
+import Header from "../components/Header";
+import LeftSidebar from "../components/LeftSidebar";
 import RightSidebar from "../components/RightSidebar/Index";
 import QuestionContentTitle from "../components/QuestionContentTitle/Index";
 import QuestionContent from "../components/QuestionContent/Index";
@@ -11,10 +13,10 @@ const Title = QuestionContentTitle;
 
 const QuestionContentPage = () => {
   return (
-    <body>
-      {/* header 컴포넌트 */}
+    <Body>
+      <Header />
       <TotalContainer>
-        {/* LeftSideBar Component */}
+        <LeftSidebar />
         <MainContainer>
           <Title />
           <Content>
@@ -27,16 +29,27 @@ const QuestionContentPage = () => {
           </Content>
         </MainContainer>
       </TotalContainer>
-    </body>
+    </Body>
   );
 };
 
 export default QuestionContentPage;
 
-const TotalContainer = styled.div``;
+const Body = styled.body`
+  width: 100vw;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const TotalContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  width: 80%;
+`;
 
 const MainContainer = styled.div`
-  width: 55vw;
+  padding: 24px;
 `;
 
 const Content = styled.div`


### PR DESCRIPTION
- 질문 상세조회 페이지 레이아웃 완성
- 페이지 컴포넌트 내부 : 좌/우측 사이드바, 중앙 메인 컨텐츠 (질문/답변 조회, 답변 작성)
- 상단 헤더는 모든 페이지에서 공통으로 사용되므로 루트 컴포넌트 (App.tsx) 로 이동
- 하단 푸터는 추후 수정하여 페이지 내부에 위치시킬 예정