### PR TITLE
[FE] #64 로그아웃 페이지 뷰 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,9 +3,10 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import styled, { createGlobalStyle } from "styled-components";
 
 import Header from "./components/Header";
-import Footer from "./components/Footer";
+// import Footer from "./components/Footer";
 import Mainpage from "./page/Mainpage";
 import QuestionContentPage from "./page/QuestionContentPage";
+import LogoutPage from "./page/LogoutPage";
 
 function App() {
   return (
@@ -17,9 +18,10 @@ function App() {
           <Routes>
             <Route path="/" element={<Mainpage />} />
             <Route path="/page/:votes" element={<QuestionContentPage />} />
+            <Route path="/users/logout" element={<LogoutPage />} />
           </Routes>
         </Wrapper>
-        <FooterBox />
+        {/* <FooterBox /> */}
       </Router>
     </>
   );
@@ -43,9 +45,9 @@ const Wrapper = styled.div`
   justify-content: center;
 `;
 
-const FooterBox = styled(Footer)`
-  position: relative;
-  transform: translateY(-100%);
-`;
+// const FooterBox = styled(Footer)`
+//   position: relative;
+//   transform: translateY(-100%);
+// `;
 
 export default App;

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from "react";
 import styled from "styled-components";
+import { Link } from "react-router-dom";
+
 import Logo from "../../asset/Header-logo.png";
 import Search from "../../asset/Header-search.png";
-
-// mainPage 연경
-import { Link } from "react-router-dom";
 
 const Header = () => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -31,7 +30,9 @@ const Header = () => {
         <Nav>
           <li>
             {isLoggedIn ? (
-              <LogoutBtn onClick={handleLogout}>Logout</LogoutBtn>
+              <Link to="users/logout">
+                <LogoutBtn onClick={handleLogout}>Logout</LogoutBtn>
+              </Link>
             ) : (
               <LoginBtn onClick={handleLogin}>Login</LoginBtn>
             )}

--- a/client/src/components/LogoutBox/Buttons.tsx
+++ b/client/src/components/LogoutBox/Buttons.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { styled } from "styled-components";
+
+const logoutButtonText: string = "Log out";
+const cancelButtonText: string = "Cancel";
+
+const Buttons = () => {
+  return (
+    <Container>
+      <LogoutButton>{logoutButtonText}</LogoutButton>
+      <CancelButton>{cancelButtonText}</CancelButton>
+    </Container>
+  );
+};
+
+export default Buttons;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: row;
+  margin-top: 16px;
+  margin-bottom: 16px;
+`;
+
+const LogoutButton = styled.button`
+  font-size: 13px;
+  width: 66px;
+  height: 35px;
+  border-radius: 0.3rem;
+  background-color: #0a95ff;
+  border: 1px solid #0a95ff;
+  color: #ffffff;
+`;
+
+const CancelButton = styled(LogoutButton)`
+  color: #0a95ff;
+  background-color: #ffff;
+  border: 1px solid #ffff;
+`;

--- a/client/src/components/LogoutBox/DomainList.tsx
+++ b/client/src/components/LogoutBox/DomainList.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { styled } from "styled-components";
+
+import { dummyDamain } from "./dummyDomain";
+
+const DomainList = () => {
+  return (
+    <TotalContainer>
+      {dummyDamain.map(content => (
+        <Content
+          key={content.domain}
+          logoImg={content.logo}
+          domain={content.domain}
+        />
+      ))}
+    </TotalContainer>
+  );
+};
+
+export default DomainList;
+
+const Content = (props: contentProps) => {
+  const { logoImg, domain } = props;
+  return (
+    <Container>
+      <Logo src={logoImg} />
+      <Domain>{domain}</Domain>
+    </Container>
+  );
+};
+
+interface contentProps {
+  logoImg: string;
+  domain: string;
+}
+
+const TotalContainer = styled.ul`
+  padding-bottom: 8px;
+  border-bottom: 1px solid #d9dbdc;
+`;
+
+const Container = styled.li`
+  list-style: none;
+  display: flex;
+  flex-direction: row;
+  margin-top: 4px;
+  margin-bottom: 4px;
+`;
+
+const Logo = styled.img`
+  width: 16px;
+  height: 16px;
+`;
+
+const Domain = styled.div`
+  font-size: 15px;
+  color: #0074cc;
+  margin: 4px;
+`;

--- a/client/src/components/LogoutBox/Index.tsx
+++ b/client/src/components/LogoutBox/Index.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { styled } from "styled-components";
+
+import DomainList from "./DomainList";
+import Buttons from "./Buttons";
+
+const waringText: string = `If you’re on a shared computer, remember to log out of your Open ID provider (Facebook, Google, Stack Exchange, etc.) as well.`;
+
+const LogoutBox = () => {
+  return (
+    <Container>
+      <DomainList />
+      <Buttons />
+      <WaringText>{waringText}</WaringText>
+    </Container>
+  );
+};
+
+export default LogoutBox;
+
+const Container = styled.div`
+  width: 316px;
+  text-align: center;
+  border-radius: 0.5rem;
+  padding: 24px;
+  background-color: #ffff;
+  box-shadow: 0px 0.5px 15px rgba(163, 161, 161, 0.31);
+`;
+
+const WaringText = styled.div`
+  text-align: start;
+  color: #6a7c7c;
+  font-size: 12px;
+  margin-top: 32px;
+  font-weight: 500;
+`;

--- a/client/src/components/LogoutBox/dummyDomain.ts
+++ b/client/src/components/LogoutBox/dummyDomain.ts
@@ -1,0 +1,16 @@
+import dummyImg from "../../asset/stack-overflow.png";
+
+export const dummyDamain: dummyProps[] = [
+  { logo: dummyImg, domain: "askubuntu.com" },
+  { logo: dummyImg, domain: "mathoverflow.net" },
+  { logo: dummyImg, domain: "serverfault.com" },
+  { logo: dummyImg, domain: "stackapps.com" },
+  { logo: dummyImg, domain: "stackexchange.com" },
+  { logo: dummyImg, domain: "stackoverflow.com" },
+  { logo: dummyImg, domain: "superuser.com" },
+];
+
+interface dummyProps {
+  logo: string;
+  domain: string;
+}

--- a/client/src/page/LogoutPage.tsx
+++ b/client/src/page/LogoutPage.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { styled } from "styled-components";
+
+import LogoutBox from "../components/LogoutBox/Index";
+
+const guideText: string = `Clicking “Log out” will log you out of the following
+domains on this device:`;
+
+const LogoutPage = () => {
+  return (
+    <TotalContainer>
+      <Container>
+        <MainContent>
+          <GuideText>{guideText}</GuideText>
+          <LogoutBox />
+        </MainContent>
+      </Container>
+    </TotalContainer>
+  );
+};
+
+export default LogoutPage;
+
+const TotalContainer = styled.div`
+  background-color: #f1f2f3;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+`;
+
+const Container = styled.div`
+  width: 80%;
+  padding: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const MainContent = styled.main`
+  width: 526px;
+  height: 66%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const GuideText = styled.section`
+  font-size: 21px;
+  color: #232629;
+  text-align: center;
+  white-space: pre-line;
+  font-weight: 520;
+  margin-bottom: 24px;
+`;


### PR DESCRIPTION
- 로그아웃 페이지 뷰 구현 (기능은 추후 추가할 예정)
- Header 컴포넌트의 Logout 버튼 클릭 시 로그아웃 페이지로 이동되도록 Link 연결

* Logout 버튼 관련된 컴포넌트 따로 디렉토리 생성해서 분리함
사유 : 페이지 컴포넌트에서 코드를 직접 작성할 경우, 추후 클릭 이벤트 코드가 추가될 시 가독성이 떨어질 수 있으므로 컴포넌트 분리하여 관리하는 게 낫다고 판단함