### PR TITLE
[FE] 질문 작성 및 수정 페이지 기능 구현

### DIFF
--- a/client/src/components/AskEditButton/Index.tsx
+++ b/client/src/components/AskEditButton/Index.tsx
@@ -3,10 +3,10 @@ import { styled } from "styled-components";
 
 const buttonText = "Review your question";
 
-const AskEditButton = () => {
+const AskEditButton = (props: any) => {
   return (
     <>
-      <Button>{buttonText}</Button>
+      <Button onClick={() => props.posting()}>{buttonText}</Button>
     </>
   );
 };
@@ -25,7 +25,7 @@ const Button = styled.button`
   border: 0;
   border-radius: 5px;
 
-  & :hover {
+  &: hover {
     cursor: pointer;
     background-color: #095691;
   }

--- a/client/src/components/AskEditForm/EditBox.tsx
+++ b/client/src/components/AskEditForm/EditBox.tsx
@@ -3,10 +3,10 @@ import { styled } from "styled-components";
 import ReactQuill from "react-quill";
 import "react-quill/dist/quill.snow.css";
 
-const EditBox = () => {
+const EditBox = (props: any) => {
   return (
     <>
-      <TextWriteForm theme="snow" />
+      <TextWriteForm theme="snow" onChange={e => props.EditBody(e)} />
     </>
   );
 };

--- a/client/src/components/AskEditForm/Index.tsx
+++ b/client/src/components/AskEditForm/Index.tsx
@@ -1,22 +1,49 @@
-import React from "react";
+import React, { useState } from "react";
 import { styled } from "styled-components";
 
 import { title, body, tags } from "./dummyForm";
 import EditBox from "./EditBox";
 
-const AskEditForm = () => {
+const AskEditForm = (props: any) => {
+  const [editTitle, setEditTitle] = useState<string>("");
+  const [editBody, setEditBody] = useState<string>("");
+  const { PostData } = props;
+
+  const EditTitle = (e: any) => {
+    setEditTitle(e.target.value);
+
+    PostData({
+      title: editTitle,
+      content: editBody,
+    });
+  };
+
+  const EditBody = (e: any) => {
+    setEditBody(e);
+
+    PostData({
+      title: editTitle,
+      content: editBody,
+    });
+  };
+
   return (
     <>
       <FormContainer>
         <Section className="TitleSection">
           <Title>{title.title}</Title>
           <SubTitle>{title.subTitle}</SubTitle>
-          <Input className="TitleInput" placeholder={title.contents} />
+          <Input
+            className="TitleInput"
+            placeholder={title.contents}
+            value={editTitle}
+            onChange={e => EditTitle(e)}
+          />
         </Section>
         <Section className="BodySection">
           <Title>{body.title}</Title>
           <SubTitle>{body.subTitle}</SubTitle>
-          <EditBox />
+          <EditBox EditBody={EditBody} />
         </Section>
         <Section className="TagsSection">
           <Title>{tags.title}</Title>

--- a/client/src/components/AskModifyForm/EditBox.tsx
+++ b/client/src/components/AskModifyForm/EditBox.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { styled } from "styled-components";
+import ReactQuill from "react-quill";
+import "react-quill/dist/quill.snow.css";
+
+const EditBox = (props: any) => {
+  const { data, EditBody } = props;
+  return (
+    <>
+      <TextWriteForm theme="snow" value={data} onChange={e => EditBody(e)} />
+    </>
+  );
+};
+
+export default EditBox;
+
+const TextWriteForm = styled(ReactQuill)`
+  height: 200px;
+
+  margin-top: 10px;
+  margin-bottom: 60px;
+`;

--- a/client/src/components/AskModifyForm/Index.tsx
+++ b/client/src/components/AskModifyForm/Index.tsx
@@ -9,8 +9,6 @@ const AskModifyForm = (props: any) => {
   const [editTitle, setEditTitle] = useState<string>(data.title);
   const [editBody, setEditBody] = useState<string>(data.content);
 
-  console.log(data);
-
   const EditTitle = (e: any) => {
     setEditTitle(e.target.value);
 

--- a/client/src/components/AskModifyForm/Index.tsx
+++ b/client/src/components/AskModifyForm/Index.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from "react";
+import { styled } from "styled-components";
+
+import { title, body, tags } from "./dummyForm";
+import EditBox from "./EditBox";
+
+const AskModifyForm = (props: any) => {
+  const { data, PostData } = props;
+  const [editTitle, setEditTitle] = useState<string>(data.title);
+  const [editBody, setEditBody] = useState<string>(data.content);
+
+  console.log(data);
+
+  const EditTitle = (e: any) => {
+    setEditTitle(e.target.value);
+
+    PostData({
+      title: editTitle,
+      content: editBody,
+    });
+  };
+
+  const EditBody = (e: any) => {
+    setEditBody(e);
+
+    PostData({
+      title: editTitle,
+      content: editBody,
+    });
+  };
+
+  return (
+    <>
+      <FormContainer>
+        <Section className="TitleSection">
+          <Title>{title.title}</Title>
+          <SubTitle>{title.subTitle}</SubTitle>
+          <Input
+            className="TitleInput"
+            placeholder={title.contents}
+            defaultValue={data.title}
+            onChange={e => EditTitle(e)}
+          />
+        </Section>
+        <Section className="BodySection">
+          <Title>{body.title}</Title>
+          <SubTitle>{body.subTitle}</SubTitle>
+          <EditBox data={data.content} EditBody={EditBody} />
+        </Section>
+        <Section className="TagsSection">
+          <Title>{tags.title}</Title>
+          <SubTitle>{tags.subTitle}</SubTitle>
+          <Input className="TagsInput" placeholder={tags.contents} />
+        </Section>
+      </FormContainer>
+    </>
+  );
+};
+
+export default AskModifyForm;
+
+const FormContainer = styled.div`
+  background-color: white;
+
+  margin-top: 20px;
+
+  padding: 35px 35px 20px 35px;
+
+  border: 1px solid #e4e5e7;
+  border-radius: 5px;
+`;
+
+const Section = styled.section`
+  margin-bottom: 20px;
+`;
+
+const Input = styled.input`
+  width: 100%;
+
+  margin-top: 7px;
+
+  padding: 7px;
+
+  border: 1px solid #c7cbcf;
+  border-radius: 5px;
+`;
+
+const Title = styled.h5`
+  margin-bottom: 3px;
+`;
+
+const SubTitle = styled.p`
+  font-size: 0.8rem;
+`;

--- a/client/src/components/AskModifyForm/dummyForm.tsx
+++ b/client/src/components/AskModifyForm/dummyForm.tsx
@@ -1,0 +1,22 @@
+const title: any = {
+  title: "Title",
+  subTitle:
+    "Be specific and imagine you’re asking a question to another person.",
+  contents:
+    "e.g. Is there an R function for finding the index of an element in a vector?",
+};
+
+const body: any = {
+  title: "Body",
+  subTitle:
+    "Introduce the problem and expand on what you put in the title. Minimum 20 characters.",
+};
+
+const tags: any = {
+  title: "Tags",
+  subTitle:
+    "Add up to 5 tags to describe what your question is about. Start typing to see suggestions.",
+  contents: "e.g. ( net typescript swift )",
+};
+
+export { title, body, tags };

--- a/client/src/page/AskEditPage.tsx
+++ b/client/src/page/AskEditPage.tsx
@@ -1,5 +1,7 @@
-import React from "react";
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { styled } from "styled-components";
+import axios from "axios";
 
 import AskEditAdvice from "../components/AskEditAdvice/Index";
 import AskEditAside from "../components/AskEditAside/Index";
@@ -7,9 +9,31 @@ import AskEditForm from "../components/AskEditForm/Index";
 import AskEditButton from "../components/AskEditButton/Index";
 import Footer from "../components/Footer";
 
+const api = "http://3.34.199.73:8080/8/posts";
 const pageTitle = "Ask a public question";
 
 const AskEditPage = () => {
+  const navigate = useNavigate();
+  const [postData, setPostData] = useState({});
+
+  const PostData = (data: postDataType) => {
+    setPostData(data);
+  };
+
+  const posting = async () => {
+    try {
+      await axios
+        .post(api, postData)
+        .then((res: any) => {
+          const path: string = `/posts/${res.data.postId}`;
+          navigate(path);
+        })
+        .catch(err => console.error(err));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <>
       <AskContainer>
@@ -20,8 +44,8 @@ const AskEditPage = () => {
           <ContentsSection>
             <EditSection>
               <AskEditAdvice />
-              <AskEditForm />
-              <AskEditButton />
+              <AskEditForm PostData={PostData} />
+              <AskEditButton posting={posting} />
             </EditSection>
             <AskEditAside />
           </ContentsSection>
@@ -33,6 +57,11 @@ const AskEditPage = () => {
 };
 
 export default AskEditPage;
+
+interface postDataType {
+  title: string;
+  content: string;
+}
 
 const AskContainer = styled.div`
   width: 100vw;

--- a/client/src/page/AskEditPage.tsx
+++ b/client/src/page/AskEditPage.tsx
@@ -9,10 +9,12 @@ import AskEditForm from "../components/AskEditForm/Index";
 import AskEditButton from "../components/AskEditButton/Index";
 import Footer from "../components/Footer";
 
-const api = "http://3.34.199.73:8080/8/posts";
+const api = "http://3.34.199.73:8080";
 const pageTitle = "Ask a public question";
 
 const AskEditPage = () => {
+  const userId = 8; //유저 정보를 로컬에 저장 후 사용할 지 결정하기
+
   const navigate = useNavigate();
   const [postData, setPostData] = useState({});
 
@@ -23,7 +25,7 @@ const AskEditPage = () => {
   const posting = async () => {
     try {
       await axios
-        .post(api, postData)
+        .post(`${api}/${userId}/posts`, postData)
         .then((res: any) => {
           const path: string = `/posts/${res.data.postId}`;
           navigate(path);

--- a/client/src/page/AskModifyPage.tsx
+++ b/client/src/page/AskModifyPage.tsx
@@ -1,15 +1,54 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 import { styled } from "styled-components";
+import axios from "axios";
 
 import AskEditAside from "../components/AskEditAside/Index";
-import AskEditForm from "../components/AskEditForm/Index";
+import AskModifyForm from "../components/AskModifyForm/Index";
 import AskEditButton from "../components/AskEditButton/Index";
 import Footer from "../components/Footer";
 import LeftSidebar from "../components/LeftSidebar";
 
 const pageTitle = "Ask a public question";
+const api = "http://3.34.199.73:8080";
 
 const AskModifyPage = () => {
+  const userId = 9; //유저 정보를 로컬에 저장 후 사용할 지 결정하기
+
+  const { postId } = useParams();
+  const navigate = useNavigate();
+  const [postData, setPostData] = useState({});
+
+  useEffect(() => {
+    axios
+      .get(`${api}/${userId}/posts/${postId}`)
+      .then((res: any) => {
+        setPostData({
+          title: res.data.title,
+          content: res.data.content,
+        });
+      })
+      .catch(err => console.error(err));
+  }, []);
+
+  const PostData = (data: postDataType) => {
+    setPostData(data);
+  };
+
+  const posting = async () => {
+    try {
+      await axios
+        .patch(`${api}/${userId}/posts/${postId}`, postData)
+        .then((res: any) => {
+          const path: string = `/posts/${res.data.postId}`;
+          navigate(path);
+        })
+        .catch(err => console.error(err));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <>
       <AskContainer>
@@ -21,8 +60,8 @@ const AskModifyPage = () => {
             </TitleSection>
             <ContentsSection>
               <EditSection>
-                <AskEditForm />
-                <AskEditButton />
+                <AskModifyForm data={postData} PostData={PostData} />
+                <AskEditButton posting={posting} />
               </EditSection>
               <AskEditAside />
             </ContentsSection>
@@ -35,6 +74,11 @@ const AskModifyPage = () => {
 };
 
 export default AskModifyPage;
+
+interface postDataType {
+  title: string;
+  content: string;
+}
 
 const AskContainer = styled.div`
   background-color: #f8f9f9;


### PR DESCRIPTION
[작성 페이지]
- api 연결 완료
- title 과 content 데이터를 백엔드로 보내 DB 에 저장 확인
- 작성이 완료 되면, 작성한 질문의 상세페이지로 이동
- tags 기능은 시간 관계로 구현 생략

[수정 페이지]
- 질문 수정 api 연결
- 기존 데이터가 수정하려는 페이지 안에 default 로 있음
- 수정 후 상세 페이지로 이동
- 기능 구현을 위하여 AskModifyForm 컴포넌트 추가

Issues : 11